### PR TITLE
Cleanup of the Confluence documentation for better dislay on the docs site

### DIFF
--- a/confluence/confluence-v1.asciidoc
+++ b/confluence/confluence-v1.asciidoc
@@ -1,5 +1,5 @@
-*Confluence REST Configuration*
--------------------------------
+== Confluence REST Configuration
+
 This documentation describes aspects of the Confluence REST `confluence-v1.json` file configuration such as the authentication methods, data crawled and retrieved, pagination information, variables used, and endpoints used. Terminology is also provided as a reference.
 
 The list of data the REST connector crawls using the Confluence REST configuration is:
@@ -10,18 +10,16 @@ The list of data the REST connector crawls using the Confluence REST configurati
 * Pages and blog posts comments that are indexed as individual solr-docs
 
 
-*Authentication methods*
-------------------------
+== Authentication methods
 
 The Confluence REST configuration supports:
 
-* Basic Authentication using the username and password from an Atlassian account. For more information, see https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/.
+* Basic Authentication using the username and password from an Atlassian account. For more information, see link:https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/[Basic auth for REST APIs | Atlassian Developer^].
 
-* API Token. For information about how to create a new API token, see https://id.atlassian.com/manage/api-tokens.
+* API Token. For information about how to create a new API token, see link:https://id.atlassian.com/manage/api-tokens[API Tokens | Atlassian ID^].
 
 
-*Supported crawl options*
--------------------------
+== Supported crawl options
 
 The Confluence REST configuration supports the following crawl options:
 
@@ -30,8 +28,7 @@ The Confluence REST configuration supports the following crawl options:
 * Recrawl that uses the `rely on the strayContentDeletion` parameter
 
 
-*Pagination information*
-------------------------
+== Pagination information
 
 This recipe is configured to use pagination by batch size. 
 
@@ -42,8 +39,7 @@ This recipe is configured to use pagination by batch size.
 * The pagination `stop` condition is set to a `results` response object set `[]`. Pagination stops when this condition is met.
 
 
-*Variables used*
-----------------
+== Variables used
 
 The Confluence REST configuration variables used are:
 
@@ -54,8 +50,7 @@ The Confluence REST configuration variables used are:
 * `${LW_PARENT_DATA_KEY}` - This variable is used to access a value of the response from the `main request` to use in an `additional request`. The Confluence use case indicates this variable can be added the URL to execute a GET request to retrieve comments for blogposts and pages.
 
 
-*Endpoints to configure with the Confluence REST connector*
------------------------------------------------------------
+== Endpoints to configure with the Confluence REST connector
 
 The following table describes the Confluence REST connector endpoints.
 
@@ -64,9 +59,10 @@ The following table describes the Confluence REST connector endpoints.
 The list of objects is retrieved in batches. Objects include spaces, pages, blogs, and comments. The default number of batch items retrieved is 25. You can configure the query limit to retrieve more objects. The maximum value to retrieve is 250.
 
 
-[options="header"]
+[options="header",cols="1m,1,1m,1,1"]
 |=======================
 |Endpoint|HTTP operation |Query parameter |Description |Request type
+
 |/wiki/rest/api/content|GET    |type=blogpost&start=0&limit=1&expand=body.storage|Returns all blogposts from the specified endpoint.|Root Request
 |/wiki/rest/api/content/${LW_PARENT_DATA_KEY}/child/comment|GET|expand=body.storage|Returns all comments in the blogposts from the specified endpoint. The value of `id` from the main request needs to be assigned to the `${LW_PARENT_DATA_KEY}` variable so the additional feature can insert that value when building the GET URL.  |Child Request
 |/wiki/rest/api/content | GET |type=paget&start=0&limit=1&expand=body.storage |Returns all pages from the specified endpoint.|Root Request
@@ -74,26 +70,25 @@ The list of objects is retrieved in batches. Objects include spaces, pages, blog
 |=======================
 
 
-*Terminology*
--------------
+== Terminology
 
 The following terms are provided as a reference.
 
-[options="header"]
+[options="header",cols="1s,1"]
 |=======================
 
 |Term|Description
-|`Service Endpoints`|The list of service endpoints from which the data is retrieved. Each service endpoint configures a root endpoint request.
-|`Root Request`|The type of request to retrieve data the root data objects.
-|`Child Request`|The type of request to retrieve additional information for the root data objects. It iterates over root data objects, and performs a request for each one.
-|`Root Response Mapping`|Defines the mapping between the response and data objects to be indexed.
-|`Child Response Mapping` |Defines the mapping between the child response and child data objects to be indexed.
-|`Data Path`|The path to access a specific data object within a response. For example, to access a list of elements named with key `objects`, the DataPath would be `objects`. If not provided, the entire response body will be indexed.
-|`DATA ID`|The identifier key for the data object where the value is the solr-document's ID. If not provided, a random universally unique identifier (UUID) will be used.
-|`Parent Data Key`|Key to extract data from the root/parent response used in the subsequent request. The extracted value is used to replace the ${LW_PARENT_DATA_KEY} variable in the child request configuration (endpoint, query params or body). For example, endpoint: /api/path/${LW_PARENT_DATA_KEY}/additionalInfo.
-|`Child Data Path`|The path to access a specific object within a child response. For example, to access a list of elements named with the key `objects`, the ChildDataPath would be `objects`. If not provided, the entire response body will be indexed.
-|`Child Data ID`|The identifier key for the child data object, where the value is the solr-document's ID. Enter this when the `Custom Solr Field` is empty, otherwise the solr-document's ID will be a random universally unique identifier (UUID).
-|`Custom Solr Field`|The field in which to store the child data within the root data objects. If not set, the child data object will be indexed as an individual solr-document.
+|Service Endpoints|The list of service endpoints from which the data is retrieved. Each service endpoint configures a root endpoint request.
+|Root Request|The type of request to retrieve data the root data objects.
+|Child Request|The type of request to retrieve additional information for the root data objects. It iterates over root data objects, and performs a request for each one.
+|Root Response Mapping|Defines the mapping between the response and data objects to be indexed.
+|Child Response Mapping |Defines the mapping between the child response and child data objects to be indexed.
+|Data Path|The path to access a specific data object within a response. For example, to access a list of elements named with key `objects`, the DataPath would be `objects`. If not provided, the entire response body will be indexed.
+|DATA ID|The identifier key for the data object where the value is the solr-document's ID. If not provided, a random universally unique identifier (UUID) will be used.
+|Parent Data Key|Key to extract data from the root/parent response used in the subsequent request. The extracted value is used to replace the ${LW_PARENT_DATA_KEY} variable in the child request configuration (endpoint, query params or body). For example, endpoint: /api/path/${LW_PARENT_DATA_KEY}/additionalInfo.
+|Child Data Path|The path to access a specific object within a child response. For example, to access a list of elements named with the key `objects`, the ChildDataPath would be `objects`. If not provided, the entire response body will be indexed.
+|Child Data ID|The identifier key for the child data object, where the value is the solr-document's ID. Enter this when the `Custom Solr Field` is empty, otherwise the solr-document's ID will be a random universally unique identifier (UUID).
+|Custom Solr Field|The field in which to store the child data within the root data objects. If not set, the child data object will be indexed as an individual solr-document.
 
 |=======================
 


### PR DESCRIPTION
The PR includes minor changes to how the headings and some tables are formatted, as well as a couple of links. It is to align the content to what the docs site expects to see, to correct formatting.